### PR TITLE
345 update env variables

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -262,6 +262,9 @@ To deploy the housing repairs api, you must first deploy `HousingRepairsScheduli
 | `LEASEHOLD_CONFIRMATION_EMAIL_NOTIFY_TEMPLATE_ID` | Gov notify email template ID for leasehold repairs, this is available once the template is created            |
 | `LEASEHOLD_CONFIRMATION_SMS_NOTIFY_TEMPLATE_ID`   | Gov notify sms template ID for leasehold repairs, this is available once the template is created              |
 | `LEASEHOLD_INTERNAL_EMAIL_NOTIFY_TEMPLATE_ID`     | Gov notify internal email template ID for leasehold repairs, this is available once the template is created   |
+| `CANCELLATION_INTERNAL_EMAIL_NOTIFY_TEMPLATE_ID`  | Gov notify internal email template ID for cancellation of repairs, this is available once the template is created   |
+| `APPOINTMENT_CHANGED_SMS_NOTIFY_TEMPLATE_ID`      | Gov notify sms template ID for changed appointments, this is available once the template is created           |
+| `APPOINTMENT_CHANGED_EMAIL_NOTIFY_TEMPLATE_ID`    | Gov notify email template ID for changed appointments, this is available once the template is created         |
 | `DAYS_UNTIL_IMAGE_EXPIRY_PRODUCTION`              | Number in days before image uploaded by customer expires for _Production_, e.g. `14` days                     |
 | `DAYS_UNTIL_IMAGE_EXPIRY_STAGING`                 | Number in days before image uploaded by customer expires for _Staging_, e.g. `14` days                        |
 | `GOV_NOTIFY_KEY_PRODUCTION`                       | _Staging_ gov notify key                                                                                      |

--- a/docs/housing-management-system-api/intro.md
+++ b/docs/housing-management-system-api/intro.md
@@ -9,32 +9,14 @@ Written in .Net
 ## Environment variables
 | Name                                   | Description                                                                                                       |
 |----------------------------------------|-------------------------------------------------------------------------------------------------------------------|
-| `APP_SERVICE_NAME`                     | App Service name (must be unique across whole of Azure), e.g. `HousingManagementSystemApi-{LOCAL_AUTHORITY_NAME}` |
-| `SERVICE_PLAN_NAME`                    | App Service Plan name, e.g. `housing-repairs-online`                                                              |
-| `AUTHENTICATION_IDENTIFIER_PRODUCTION` | A unique identifier used to validate access in production.*                                                       |
-| `AUTHENTICATION_IDENTIFIER_STAGING`    | A unique identifier used to validate access in staging.*                                                          |
-| `AZURE_AD_CLIENT_SECRET`               | This is the client secret value that was generated for the service principal in section 4 of Create a service     |
-| `AZURE_AD_CLIENT_ID`                   | This is the Application (client) ID                                                                               |
-| `AZURE_AD_TENANT_ID`                   | This is the Directory (tenant) ID                                                                                 |
-| `AZURE_SUBSCRIPTION_ID`                | Navigate to subscriptions and select the Subscription ID for your subscription                                    |
-| `ANCM_ADDITIONAL_ERROR_PAGE_LINK_PRODUCTION`  | Set the value to the correct path for production Module                                          |
-| `ANCM_ADDITIONAL_ERROR_PAGE_LINK_STAGING`  | Set the value to the correct path for staging Module                                                |
-| `JWT_SECRET_PRODUCTION`                | JWT secret generated for for production.*                                                                         |
-| `JWT_SECRET_STAGING`                   | JWT secret generated for for staging.*                                                                            |
-| `NUGET_AUTH_GITHUB_TOKEN`              | Authentication token for authenticating with GitHub NuGet feed                                                    |
-| `NUGET_AUTH_GITHUB_USERNAME`           | Username for authenticating with GitHub NuGet feed                                                                |
+| `AUTHENTICATION_IDENTIFIER`            | A unique identifier used to validate access. *                                                                    |        
+| `ANCM_ADDITIONAL_ERROR_PAGE_LINK`      | Set the value to the correct path                                                                                 |
+| `JWT_SECRET`                           | JWT secret as generated.*                                                                                         |
 | `SENTRY_DSN`                           | [Sentry Data Source Name](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)                            |
-| `RESOURCE_GROUP_LOCATION`              | The resource group location housing your Terraform state file, e.g. `UK South`                                    |
-| `RESOURCE_GROUP_NAME`                  | The resource group name housing your Terraform state file                                                         |
-| `STORAGE_ACCOUNT_NAME`                 | The name of the Azure Storage Account to house your Terraform state file                                          |
-| `STATE_CONTAINER_NAME`                 | The name of the Azure Blob Storage container to house your Terraform state file                                   |
-| `STATE_KEY_NAME`                       | The file path and name of your Terraform state file                                                               |
 | `COSMOS_DATABASE_ID`                   | DocumentDB (e.g. CosmosDB) database name                                                                          |
 | `COSMOS_TENANT_CONTAINER_ID`           | DocumentDB (e.g. CosmosDB) container name for tenant addresses, e.g. `addresses`                                  |
-| `COSMOS_COMMUNAL_STAGING_CONTAINER_ID`    | DocumentDB (e.g. CosmosDB) container name for staging communal addresses, e.g. `addresses`                     |
-| `COSMOS_COMMUNAL_PRODUCTION_CONTAINER_ID` | DocumentDB (e.g. CosmosDB) container name for production communal addresses, e.g. `addresses`                  |
-| `COSMOS_LEASEHOLD_STAGING_CONTAINER_ID`   | DocumentDB (e.g. CosmosDB) container name for staging leasehold addresses, e.g. `addresses`                    |
-| `COSMOS_LEASEHOLD_PRODUCTION_CONTAINER_ID`| DocumentDB (e.g. CosmosDB) container name for production leasehold addresses, e.g `addresses`                  |
+| `COSMOS_COMMUNAL_CONTAINER_ID`         | DocumentDB (e.g. CosmosDB) container name for communal addresses, e.g. `addresses`                                |
+| `COSMOS_LEASEHOLD_CONTAINER_ID`        | DocumentDB (e.g. CosmosDB) container name for leasehold addresses, e.g. `addresses`                               |
 | `COSMOS_ENDPOINT_URL`                  | DocumentDB (e.g. CosmosDB) account endpoint URL                                                                   |
 | `COSMOS_AUTHORIZATION_KEY`             | DocumentDB (e.g. CosmosDB) account primary key                                                                    |
 | `CAPITAOPTIONS__APIADDRESS`            | Capita Service URL                                                                                                |

--- a/docs/repairs-api/intro.md
+++ b/docs/repairs-api/intro.md
@@ -163,6 +163,9 @@ Email notification template ID is configured via [environment variables](#i-emai
 | LEASEHOLD_CONFIRMATION_EMAIL_NOTIFY_TEMPLATE_ID | Gov notify email template ID for leasehold repairs, this is available once the template is created            |
 | LEASEHOLD_CONFIRMATION_SMS_NOTIFY_TEMPLATE_ID   | Gov notify sms template ID for leasehold repairs, this is available once the template is created              |
 | LEASEHOLD_INTERNAL_EMAIL_NOTIFY_TEMPLATE_ID     | Gov notify internal email template ID for leasehold repairs, this is available once the template is created   |
+| CANCELLATION_INTERNAL_EMAIL_NOTIFY_TEMPLATE_ID     | Gov notify internal email template ID for cancellation of repairs, this is available once the template is created   |
+| APPOINTMENT_CHANGED_SMS_NOTIFY_TEMPLATE_ID     | Gov notify sms template ID for changed appointments, this is available once the template is created   |
+| APPOINTMENT_CHANGED_EMAIL_NOTIFY_TEMPLATE_ID     | Gov notify email template ID for changed appointments, this is available once the template is created   |
 | INTERNAL_EMAIL                       | Internal email address for receiving repair request details, for any manual follow-on process |
 | DAYS_UNTIL_IMAGE_EXPIRY              | Number in days before image uploaded by customer expires, e.g. `14` days                     |
 | [SENTRY_DSN](../alerting-and-monitoring/intro#azure-component-setup)      | [Sentry Data Source Name](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)                                      | 

--- a/docs/repairs-api/intro.md
+++ b/docs/repairs-api/intro.md
@@ -143,25 +143,17 @@ Email notification template ID is configured via [environment variables](#i-emai
 ## Environment variables
 | Name                                                                      |  Description                                                                          |
 |---------------------------------------------------------------------------|---------------------------------------------------------------------------------------|
-| AUTHENTICATION_IDENTIFIER_PRODUCTION            | A unique identifier used to validate access for _Production_                                                  |
-| AUTHENTICATION_IDENTIFIER_STAGING               | A unique identifier used to validate access for _Staging_                                                     |
-| JWT_SECRET_PRODUCTION                           | JWT secret generated for for _Production_                                                                     |
-| JWT_SECRET_STAGING                              | JWT secret generated for for _Staging_                                                                        |
-| NUGET_AUTH_GITHUB_TOKEN                         | Authentication token for authenticating with GitHub NuGet feed                                                |
-| NUGET_AUTH_GITHUB_USERNAME                      | Username for authenticating with GitHub NuGet feed                                                            |
-| [ADDRESSES_API_URL_PRODUCTION](../housing-management-system-api/intro)                    | Retrieve from App Service once HousingManagementSystemApi is deployed                     |
-| [ADDRESSES_API_URL_STAGING](../housing-management-system-api/intro)                       | Retrieve from App Service _Staging_ slot once HousingManagementSystemApi is deployed      |
-| [SCHEDULING_API_URL_PRODUCTION](../scheduling-api/intro)                | Retrieve from App Service once HousingRepairsSchedulingApi is deployed                                      |
-| [SCHEDULING_API_URL_STAGING](../scheduling-api/intro)                      | Retrieve from App Service _Staging_ slot once HousingRepairsSchedulingApi is deployed                    |
+| AUTHENTICATION_IDENTIFIER                       | A unique identifier used to validate access                                                |
+| JWT_SECRET                                      | JWT secret generated                                                                      |
+| [ADDRESSES_API_URL](../housing-management-system-api/intro)                    | Retrieve from App Service once HousingManagementSystemApi is deployed                     |
+| [SCHEDULING_API_URL](../scheduling-api/intro)                      | Retrieve from App Service _Staging_ slot once HousingRepairsSchedulingApi is deployed                    |
 | <span id="cosmos-env">COSMOS_ENDPOINT_URL</span>                          | Cosmos endpoint URL                                                                 |
 | COSMOS_AUTHORIZATION_KEY                                                  | Cosmos authorization key                                                            |
 | COSMOS_DATABASE_ID                                                        | Cosmos database name, e.g.: `housing-repairs-online`                                |
 | COSMOS_CONTAINER_ID                                                       | Cosmos table name, e.g.: `repairs-requests`                                         |
 | <span id="blob-env">AZURE_STORAGE_CONNECTION_STRING</span>                | Blob storage connection string                                                      |
-| STORAGE_CONTAINER_NAME_PRODUCTION               | Storage container name for _Production_, e.g. `housing-repairs-online`                                        |
-| STORAGE_CONTAINER_NAME_STAGING                  | Storage container name for _Staging_, e.g. `housing-repairs-online-staging`                                   |
-| GOV_NOTIFY_KEY_PRODUCTION                                                            | Gov notification key                                                                |
-| GOV_NOTIFY_KEY_STAGING                                                            | Gov notification key                                                                |
+| STORAGE_CONTAINER_NAME              | Storage container name, e.g. `housing-repairs-online`                                        |
+| GOV_NOTIFY_KEY                                                           | Gov notification key                                                                |
 | TENANT_CONFIRMATION_EMAIL_NOTIFY_TEMPLATE_ID    | Gov notify email template ID for tenant repairs, this is available once the template is created               |
 | TENANT_CONFIRMATION_SMS_NOTIFY_TEMPLATE_ID      | Gov notify sms template ID for tenant repairs, this is available once the template is created                 |
 | TENANT_INTERNAL_EMAIL_NOTIFY_TEMPLATE_ID        | Gov notify internal email template ID for tenant repairs, this is available once the template is created      |
@@ -171,21 +163,14 @@ Email notification template ID is configured via [environment variables](#i-emai
 | LEASEHOLD_CONFIRMATION_EMAIL_NOTIFY_TEMPLATE_ID | Gov notify email template ID for leasehold repairs, this is available once the template is created            |
 | LEASEHOLD_CONFIRMATION_SMS_NOTIFY_TEMPLATE_ID   | Gov notify sms template ID for leasehold repairs, this is available once the template is created              |
 | LEASEHOLD_INTERNAL_EMAIL_NOTIFY_TEMPLATE_ID     | Gov notify internal email template ID for leasehold repairs, this is available once the template is created   |
-| INTERNAL_EMAIL_PRODUCTION                       | Internal email address for receiving repair request details, for any manual follow-on process in _Production_ |
-| INTERNAL_EMAIL_STAGING                          | Internal email address for receiving repair request details, for any manual follow-on process in _Staging_    |
-| DAYS_UNTIL_IMAGE_EXPIRY_PRODUCTION              | Number in days before image uploaded by customer expires for _Production_, e.g. `14` days                     |
-| DAYS_UNTIL_IMAGE_EXPIRY_STAGING                 | Number in days before image uploaded by customer expires for _Staging_, e.g. `14` days                        |
+| INTERNAL_EMAIL                       | Internal email address for receiving repair request details, for any manual follow-on process |
+| DAYS_UNTIL_IMAGE_EXPIRY              | Number in days before image uploaded by customer expires, e.g. `14` days                     |
 | [SENTRY_DSN](../alerting-and-monitoring/intro#azure-component-setup)      | [Sentry Data Source Name](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)                                      | 
-| SOR_CONFIGURATION_TENANT_PRODUCTION                                       | [Schedule of Rates configuration](sor-engine/#configuration) that specifies tenant options to offer and their SoR code for production     |
-| SOR_CONFIGURATION_COMMUNAL_PRODUCTION                                     | [Schedule of Rates configuration](sor-engine/#configuration) that specifies communal options to offer and their SoR code for production     |
-| SOR_CONFIGURATION_LEASEHOLD_PRODUCTION                                       | [Schedule of Rates configuration](sor-engine/#configuration) that specifies leasehold options to offer and their SoR code for production |
-| SOR_CONFIGURATION_TENANT_STAGING                                          | [Schedule of Rates configuration](sor-engine/#configuration) that specifies tenant options to offer and their SoR code for staging        |
-| SOR_CONFIGURATION_COMMUNAL_STAGING                                        | [Schedule of Rates configuration](sor-engine/#configuration) that specifies communal options to offer and their SoR code for staging        |
-| SOR_CONFIGURATION_LEASEHOLD_STAGING                                       | [Schedule of Rates configuration](sor-engine/#configuration) that specifies leasehold options to offer and their SoR code for staging    |
-| SERVICE_NAME                                    | Service name (must be unique across whole of Azure) e.g. `housing-repairs-online-api-{LOCAL_AUTHORITY_NAME}`  |
+| SOR_CONFIGURATION_TENANT                                       | [Schedule of Rates configuration](sor-engine/#configuration) that specifies tenant options to offer and their SoR code      |
+| SOR_CONFIGURATION_COMMUNAL                                     | [Schedule of Rates configuration](sor-engine/#configuration) that specifies communal options to offer and their SoR code      |
+| SOR_CONFIGURATION_LEASEHOLD                                       | [Schedule of Rates configuration](sor-engine/#configuration) that specifies leasehold options to offer and their SoR code  |
 | ALLOWED_APPOINTMENT_SLOTS                                                 | Specifies which appointment slots are allowed (see [below](#allowed-appointment-slots) for details)                         |
-| REPAIR_PRIORITY_TO_DAYS_PRODUCTION                                        | Specifies the priority to repair days mapping for production (see [below](#repair-days-mapping) for details)                |
-| REPAIR_PRIORITY_TO_DAYS_STAGING                                           | Specifies the priority to repair days mapping for staging (see [below](#repair-days-mapping) for details)                   |
+| REPAIR_PRIORITY_TO_DAYS                                        | Specifies the priority to repair days mapping (see [below](#repair-days-mapping) for details)                |
 
 \* See [Authentication](../apis/authentication) for more details.
 

--- a/docs/scheduling-api/intro.md
+++ b/docs/scheduling-api/intro.md
@@ -11,10 +11,10 @@ Written in .Net
 |----------------------------------------|----------------------------------------------------------------------------------------------------------------------|
 | `AUTHENTICATION_IDENTIFIER` | A unique identifier used to validate access used to validate access. *                                                          |
 | `JWT_SECRET`                | JWT secret. *                                                                                                                   |
-| `DRS_API_ADDRESS`           | Live/production DRS API address, e.g. `https://yourserver/OTWebServiceGateway_INSTANCENAME/ws/soap?wsdl`                        |
-| `DRS_CONTRACT`              | Contract value to use when making requests to DRS in production                                                                 |
-| `DRS_LOGIN`                 | DRS login/user name in production                                                                                               |
-| `DRS_PASSWORD`              | DRS password in production                                                                                                      |
+| `DrsOptions__ApiAddress`    | Live/production DRS API address, e.g. `https://yourserver/OTWebServiceGateway_INSTANCENAME/ws/soap?wsdl`                        |
+| `DrsOptions__Contract`      | Contract value to use when making requests to DRS in production                                                                 |
+| `DrsOptions__Login`         | DRS login/user name in production                                                                                               |
+| `DrsOptions__Password`      | DRS password in production                                                                                                      |
 | `SENTRY_DSN`                | [Sentry Data Source Name](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)                                          |
 
 \* See [Authentication](../apis/authentication) for more details.

--- a/docs/scheduling-api/intro.md
+++ b/docs/scheduling-api/intro.md
@@ -9,31 +9,13 @@ Written in .Net
 ## Environment variables
 | Name                                   | Description                                                                                                          |
 |----------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| `APP_SERVICE_NAME`                     | Service name (must be unqiue across whole of Azure) e.g. `housing-repairs-scheduling-api-{LOCAL_AUTHORITY_NAME}`     |
-| `AUTHENTICATION_IDENTIFIER_PRODUCTION` | A unique identifier used to validate access used to validate access in production.*                                  |
-| `AUTHENTICATION_IDENTIFIER_STAGING`    | A unique identifier used to validate access used to validate access in staging.*                                     |
-| `AZURE_AD_TENANT_ID`                   | This is the Directory (tenant) ID                                                                                    |
-| `DRS_API_ADDRESS_PRODUCTION`           | Live/production DRS API address, e.g. `https://yourserver/OTWebServiceGateway_INSTANCENAME/ws/soap?wsdl`             |
-| `DRS_API_ADDRESS_STAGING`              | Test/staging DRS API address, e.g. `https://yourserver/OTWebServiceGateway_INSTANCENAME/ws/soap?wsdl`                |
-| `DRS_CONTRACT_PRODUCTION`              | Contract value to use when making requests to DRS in production                                                      |
-| `DRS_CONTRACT_STAGING`                 | Contract value to use when making requests to DRS in staging                                                         |
-| `DRS_LOGIN_PRODUCTION`                 | DRS login/user name in production                                                                                    |
-| `DRS_LOGIN_STAGING`                    | DRS login/user name in staging                                                                                       |
-| `DRS_PASSWORD_PRODUCTION`              | DRS password in production                                                                                           |
-| `DRS_PASSWORD_STAGING`                 | DRS password in staging                                                                                              |
-| `DRS_PRIORITY_PRODUCTION`              | Priority to use when making requests to DRS in production                                                            |
-| `DRS_PRIORITY_STAGING`                 | Priority to use when making requests to DRS in staging                                                               |
-| `JWT_SECRET_PRODUCTION`                | JWT secret generated for production.*                                                                                |
-| `JWT_SECRET_STAGING`                   | JWT secret generated for staging.*                                                                                   |
-| `NUGET_AUTH_GITHUB_TOKEN`              | Authentication token for authenticating with GitHub NuGet feed                                                       |
-| `NUGET_AUTH_GITHUB_USERNAME`           | Username for authenticating with GitHub NuGet feed                                                                   |
-| `RESOURCE_GROUP_LOCATION`              | Azure Resource Group location, e.g. `UK South`                                                                       |
-| `RESOURCE_GROUP_NAME`                  | Azure Resource Group name                                                                                            |
-| `SENTRY_DSN`                           | [Sentry Data Source Name](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)                               |
-| `SERVICE_PLAN_NAME`                    | Service plan name (must be unique across whole of Azure) e.g. `housing-repairs-schduling-api-{LOCAL_AUTHORITY_NAME}` |
-| `STATE_CONTAINER_NAME`                 | The name of the container to store Terraform state in                                                                |
-| `STATE_KEY_NAME`                       | The file path and name of your Terraform state file                                                                  |
-| `STORAGE_ACCOUNT_NAME`                 | Storage account name for Terraform state, e.g. `housing-repairs-online`                                              |
+| `AUTHENTICATION_IDENTIFIER` | A unique identifier used to validate access used to validate access. *                                                          |
+| `JWT_SECRET`                | JWT secret. *                                                                                                                   |
+| `DRS_API_ADDRESS`           | Live/production DRS API address, e.g. `https://yourserver/OTWebServiceGateway_INSTANCENAME/ws/soap?wsdl`                        |
+| `DRS_CONTRACT`              | Contract value to use when making requests to DRS in production                                                                 |
+| `DRS_LOGIN`                 | DRS login/user name in production                                                                                               |
+| `DRS_PASSWORD`              | DRS password in production                                                                                                      |
+| `SENTRY_DSN`                | [Sentry Data Source Name](https://docs.sentry.io/product/sentry-basics/dsn-explainer/)                                          |
 
 \* See [Authentication](../apis/authentication) for more details.
 


### PR DESCRIPTION
Update API intro pages to show only config settings required by the APIs. Previously these pages were polluted by adding Secrets. Secrets are used by the GitHub Actions/Terraform layer to set config values for the APIs. 